### PR TITLE
Fixed feature detection failing with RequireJS

### DIFF
--- a/js/modals.js
+++ b/js/modals.js
@@ -27,8 +27,8 @@
 
 	var exports = {}; // Object for public APIs
 	var supports = !!document.querySelector &&
-				   (!!root.addEventListener ||
-				   (typeof window !== 'undefined' && !!window.addEventListener)); // Feature test
+	               (!!root.addEventListener ||
+	               (typeof window !== 'undefined' && !!window.addEventListener)); // Feature test
 
 	// Default settings
 	var defaults = {


### PR DESCRIPTION
When using RequireJS, root refers to the require function and so the feature detection test will always fail.
